### PR TITLE
Add check for autoPlay in componentDidUpdate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -324,8 +324,8 @@ class H5AudioPlayer extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { src } = this.props
-    if (src !== prevProps.src) {
+    const { src, autoPlay } = this.props
+    if (src !== prevProps.src && autoPlay) {
       this.audio.play()
     }
   }


### PR DESCRIPTION
Prevents audio being played automatically when the player src has changed - see issue: https://github.com/lhz516/react-h5-audio-player/issues/9