### PR TITLE
Volume Bar Fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The `controls` attribute defaults to `false` and should never be changed to `tru
 | showJumpControls         | boolean           | true    | Show Rewind/Forward buttons |
 | showDownloadProgress     | boolean           | true    | Show download progress over progress bar |
 | showFilledProgress       | boolean           | true    | Show filled (already played) area on progress bar |
+| showFilledVolume         | boolean           | true    | Show filled volume area on volume bar |
 | autoPlayAfterSrcChange   | boolean           | true    | Play audio after `src` is changed, no matter `autoPlay` is `true` or `false` |
 | volumeJumpStep           | number            | 0.1     | Indicates the volume jump step when pressing up/down arrow key, volume range is `0` to `1` |
 | progressJumpStep         | number            | 5000    | **Deprecated, use progressJumpSteps.** Indicates the progress jump step (ms) when clicking rewind/forward button or left/right arrow key |

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The `controls` attribute defaults to `false` and should never be changed to `tru
 | showDownloadProgress     | boolean           | true    | Show download progress over progress bar |
 | showFilledProgress       | boolean           | true    | Show filled (already played) area on progress bar |
 | showFilledVolume         | boolean           | true    | Show filled volume area on volume bar |
-| autoPlayAfterSrcChange   | boolean           | true    | Play audio after `src` is changed, no matter `autoPlay` is `true` or `false` |
+| autoPlayAfterSrcChange   | boolean           | false    | Play audio after `src` is changed, no matter `autoPlay` is `true` or `false` |
 | volumeJumpStep           | number            | 0.1     | Indicates the volume jump step when pressing up/down arrow key, volume range is `0` to `1` |
 | progressJumpStep         | number            | 5000    | **Deprecated, use progressJumpSteps.** Indicates the progress jump step (ms) when clicking rewind/forward button or left/right arrow key |
 | progressJumpSteps        | object            | `{ backward: 5000, forward: 5000 }`    | Indicates the progress jump step (ms) when clicking rewind/forward button or left/right arrow key|

--- a/src/VolumeBar.test.js
+++ b/src/VolumeBar.test.js
@@ -14,7 +14,12 @@ describe('VolumeBar', () => {
         }),
       },
     }
-    const wrapper = shallow(<VolumeBar audio={null} volumeBar={mockRef} />)
+    const wrapper = shallow(
+      <VolumeBar
+        audio={null}
+        volumeBar={mockRef}
+        showFilledVolume={true}
+      />)
     expect(wrapper.state('currentVolumePos')).toBe('0.00%')
 
     const instance = wrapper.instance()
@@ -85,11 +90,9 @@ describe('VolumeBar', () => {
     }
     const wrapper = shallow(
       <VolumeBar
-        showFilledProgress={true}
-        showDownloadProgress={true}
-        progressUpdateInterval={20}
         audio={null}
         progressBar={mockRef}
+        showFilledVolume={true}
       />
     )
     expect(wrapper.state('currentVolumePos')).toBe('0.00%')
@@ -129,11 +132,9 @@ describe('VolumeBar', () => {
     }
     const wrapper = shallow(
       <VolumeBar
-        showFilledProgress={true}
-        showDownloadProgress={true}
-        progressUpdateInterval={20}
         audio={null}
         progressBar={mockRef}
+        showFilledVolume={true}
       />
     )
     expect(wrapper.state('currentVolumePos')).toBe('0.00%')
@@ -161,7 +162,7 @@ describe('VolumeBar', () => {
   })
 
   it('should not throw when unmount even if no audio object passed in', () => {
-    const wrapper = shallow(<VolumeBar audio={null} />)
+    const wrapper = shallow(<VolumeBar audio={null} showFilledVolume={true} />)
 
     wrapper.setProps({ audio: null })
     expect(() => {

--- a/src/VolumeBar.tsx
+++ b/src/VolumeBar.tsx
@@ -5,6 +5,7 @@ interface VolumeControlsProps {
   audio: HTMLAudioElement
   volume: number
   onMuteChange: () => void
+  showFilledVolume: boolean
 }
 
 interface VolumeControlsState {
@@ -161,7 +162,7 @@ class VolumeControls extends Component<VolumeControlsProps, VolumeControlsState>
   }
 
   render(): React.ReactNode {
-    const { audio } = this.props
+    const { audio, showFilledVolume } = this.props
     const { currentVolumePos, hasVolumeAnimation } = this.state
 
     const { volume } = audio || {}
@@ -184,6 +185,7 @@ class VolumeControls extends Component<VolumeControlsProps, VolumeControlsState>
             className="rhap_volume-indicator"
             style={{ left: currentVolumePos, transitionDuration: hasVolumeAnimation ? '.1s' : '0s' }}
           />
+          {showFilledVolume && <div className="rhap_volume-filled" style={{ width: currentVolumePos }} />}
         </div>
       </div>
     )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -149,7 +149,7 @@ class H5AudioPlayer extends Component<PlayerProps> {
     showSkipControls: false,
     showDownloadProgress: true,
     showFilledProgress: true,
-    showFilledVolume: true,
+    showFilledVolume: false,
     customIcons: {},
     customProgressBarSection: [RHAP_UI.CURRENT_TIME, RHAP_UI.PROGRESS_BAR, RHAP_UI.DURATION],
     customControlsSection: [RHAP_UI.ADDITIONAL_CONTROLS, RHAP_UI.MAIN_CONTROLS, RHAP_UI.VOLUME_CONTROLS],

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,6 +101,7 @@ interface PlayerProps {
   showSkipControls?: boolean
   showDownloadProgress?: boolean
   showFilledProgress?: boolean
+  showFilledVolume?: boolean
   timeFormat?: TIME_FORMAT
   header?: ReactNode
   footer?: ReactNode
@@ -148,6 +149,7 @@ class H5AudioPlayer extends Component<PlayerProps> {
     showSkipControls: false,
     showDownloadProgress: true,
     showFilledProgress: true,
+    showFilledVolume: true,
     customIcons: {},
     customProgressBarSection: [RHAP_UI.CURRENT_TIME, RHAP_UI.PROGRESS_BAR, RHAP_UI.DURATION],
     customControlsSection: [RHAP_UI.ADDITIONAL_CONTROLS, RHAP_UI.MAIN_CONTROLS, RHAP_UI.VOLUME_CONTROLS],
@@ -312,6 +314,7 @@ class H5AudioPlayer extends Component<PlayerProps> {
       progressUpdateInterval,
       showDownloadProgress,
       showFilledProgress,
+      showFilledVolume,
       defaultDuration,
       customIcons,
       showSkipControls,
@@ -486,7 +489,12 @@ class H5AudioPlayer extends Component<PlayerProps> {
             >
               {volumeIcon}
             </button>
-            <VolumeBar audio={this.audio.current} volume={volume} onMuteChange={this.handleMuteChange} />
+            <VolumeBar
+              audio={this.audio.current}
+              volume={volume}
+              onMuteChange={this.handleMuteChange}
+              showFilledVolume={showFilledVolume}
+            />
           </div>
         )
       }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -245,6 +245,14 @@ $rhap_font-family: inherit !default;
   }
 }
 
+.rhap_volume-filled {
+  height: 100%;
+  position: absolute;
+  z-index: 2;
+  background-color: $rhap_theme-color;
+  border-radius: 2px;
+}
+
 /* Utils */
 .rhap_button-clear {
   background-color: transparent;


### PR DESCRIPTION
Closes #78

This adds the `showFilledVolume` property to the player options as well as to the `VolumeBar` component.

**Preview:**
<img alt="preview" src="https://puu.sh/GPFMP/99d5c63909.png" />