### PR TITLE
clear scss(vendorPrefix) warning

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -82,6 +82,7 @@ $rhap_font-family: inherit !default;
   align-self: center;
   margin: 0 calc(10px + 1%);
   cursor: pointer;
+  user-select: none;
   -webkit-user-select: none;
 
   &:focus:not(:focus-visible) {
@@ -202,6 +203,7 @@ $rhap_font-family: inherit !default;
   display: flex;
   align-items: center;
   flex: 0 1 100px;
+  user-select: none;
   -webkit-user-select: none;
 }
 


### PR DESCRIPTION
clear two` scss(vendorPrefix)` warnings : `Also define the standard property 'user-select' for compatibility`

```
{
	"resource": ".../node_modules/react-h5-audio-player/src/styles.scss",
	"owner": "_generated_diagnostic_collection_name_#3",
	"code": "vendorPrefix",
	"severity": 4,
	"message": "Also define the standard property 'user-select' for compatibility",
	"source": "scss",
	"startLineNumber": 85,
	"startColumn": 3,
	"endLineNumber": 85,
	"endColumn": 22
}
```

```
{
	"resource": ".../node_modules/react-h5-audio-player/src/styles.scss",
	"owner": "_generated_diagnostic_collection_name_#3",
	"code": "vendorPrefix",
	"severity": 4,
	"message": "Also define the standard property 'user-select' for compatibility",
	"source": "scss",
	"startLineNumber": 206,
	"startColumn": 3,
	"endLineNumber": 206,
	"endColumn": 22
}
```