### PR TITLE
Fixes the mounting issue introduced by React 18's new strict mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -698,7 +698,6 @@ class H5AudioPlayer extends Component<PlayerProps> {
       audio.removeEventListener('play', this.handlePlay)
       audio.removeEventListener('pause', this.handlePause)
       audio.removeEventListener('abort', this.handleAbort)
-      audio.removeAttribute('src')
       audio.load()
     }
   }


### PR DESCRIPTION
Should fix this issue: https://github.com/lhz516/react-h5-audio-player/issues/169#issuecomment-1255343175