### PR TITLE
fix(jump steps) jumping back/fwd throws error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -158,6 +158,14 @@ class H5AudioPlayer extends Component<PlayerProps> {
     volumeMute: 'Unmute',
   }
 
+  static defaultProps: Partial<PlayerProps> = {
+    progressJumpSteps: {
+      backward: 5_000,
+      forward: 5_000,
+    },
+    progressJumpStep: 5_000,
+  }
+
   audio = createRef<HTMLAudioElement>()
 
   progressBar = createRef<HTMLDivElement>()


### PR DESCRIPTION
Fixes: https://github.com/lhz516/react-h5-audio-player/issues/242 and probably https://github.com/lhz516/react-h5-audio-player/issues/237
- The readme says default `progressJumpSteps` and `progressJumpStep` is `5000`
- but it is not set anywhere. Clicking forward or backward throws a TypeError.
- this sets the default to `5_000`

Repro steps:
1. open storybook and choose Actions > Actions
2. click forward or backward
3. it errors

or use the default config with npm, it errors.

note: i dont know why codepen doesn't error, possible bundle/build thing?

![CleanShot 2025-03-24 at 14 17 13](https://github.com/user-attachments/assets/3d970e7a-ac64-4f36-b356-74874a3e039f)

