### PR TITLE
Support multiple source elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ lib/
 es/
 coverage/
 .vscode/
+.DS_Store
 
 # yarn
 .yarn/

--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ The `controls` attribute defaults to `false` and should never be changed to `tru
 | showFilledProgress       | boolean           | true    | Show filled (already played) area on progress bar |
 | showFilledVolume         | boolean           | false   | Show filled volume area on volume bar |
 | hasDefaultKeyBindings    | boolean           | true    | Whether has default keyboard shortcuts |
-| autoPlayAfterSrcChange   | boolean           | true    | Play audio after `src` or `srcKey` is changed, no matter `autoPlay` is `true` or `false` |
-| autoLoadAfterSrcChange   | boolean           | true    | Load audio after `src` or `srcKey` is changed, necessary if using child `<source>` elements |
+| autoPlayAfterSrcChange   | boolean           | true    | Play audio after `src` is changed, no matter `autoPlay` is `true` or `false` |
 | volumeJumpStep           | number            | 0.1     | Indicates the volume jump step when pressing up/down arrow key, volume range is `0` to `1` |
 | progressJumpStep         | number            | 5000    | **Deprecated, use progressJumpSteps.** Indicates the progress jump step (ms) when clicking rewind/forward button or left/right arrow key |
 | progressJumpSteps        | object            | `{ backward: 5000, forward: 5000 }`    | Indicates the progress jump step (ms) when clicking rewind/forward button or left/right arrow key|
@@ -126,12 +125,6 @@ The `controls` attribute defaults to `false` and should never be changed to `tru
 | mse.srcDuration          | number           | -        | The complete duration of the MSE audio chunks together (this is a key of the _mse_ prop) |
 | mse.onSeek               | Function (Event) | -        | The callback to be used when seek happens (this is a key of the _mse_ prop) |
 | mse.srcDuration          | number           | -        | The callback to be used when encrypted audio is detected and needs to be decrypted (this is a key of the _mse_ prop) |
-
-### Other Props
-
-| Props                    | Type              | Default | Note |
-| ------------------------ | ----------------- | ------- | ---- |
-| srcKey                   | string            | ''      | A unique key for the current audio source when not using the `src` prop, i.e., when using child `<source>` elements with a playlist. |
 
 ### Event Props
 
@@ -218,14 +211,29 @@ You can use child `<source>` elements instead of the `src` prop, for example [to
 </AudioPlayer>
 ```
 
-When using `<source>` elements in playlists, use the `srcKey` prop to specify a unique identifier for the current src.
+When using `<source>` elements in playlists, be sure to set a unique `key`
+property for each element.
 
 ```jsx
-<AudioPlayer srcKey="https://example.com/audio.wav">
-  <source src="https://example.com/audio.aac" type="audio/aac" />
-  <source src="https://example.com/audio.ogg" type="audio/ogg" />
-  <source src="https://example.com/audio.mp3" type="audio/mpeg" />
-  <source src="https://example.com/audio.wav" type="audio/wav" />
+const srcs = [
+  [
+    { src: 'https://example.com/audio1.aac', type: 'audio/aac' },
+    { src: 'https://example.com/audio1.mp3', type: 'audio/mpeg' },
+    { src: 'https://example.com/audio1.wav', type: 'audio/wav' },
+  ],
+  [
+    { src: 'https://example.com/audio2.aac', type: 'audio/aac' },
+    { src: 'https://example.com/audio2.mp3', type: 'audio/mpeg' },
+    { src: 'https://example.com/audio2.wav', type: 'audio/wav' },
+  ],
+]
+
+const currentIndex = 0
+
+<AudioPlayer>
+  {srcs[currentIndex].map(({ src, type }) => (
+    <source key={src} src={src} type={type} />
+  ))}
 </AudioPlayer>
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ The `controls` attribute defaults to `false` and should never be changed to `tru
 | showFilledProgress       | boolean           | true    | Show filled (already played) area on progress bar |
 | showFilledVolume         | boolean           | false   | Show filled volume area on volume bar |
 | hasDefaultKeyBindings    | boolean           | true    | Whether has default keyboard shortcuts |
-| autoPlayAfterSrcChange   | boolean           | true    | Play audio after `src` is changed, no matter `autoPlay` is `true` or `false` |
+| autoPlayAfterSrcChange   | boolean           | true    | Play audio after `src` or `srcKey` is changed, no matter `autoPlay` is `true` or `false` |
+| autoLoadAfterSrcChange   | boolean           | true    | Load audio after `src` or `srcKey` is changed, necessary if using child `<source>` elements |
 | volumeJumpStep           | number            | 0.1     | Indicates the volume jump step when pressing up/down arrow key, volume range is `0` to `1` |
 | progressJumpStep         | number            | 5000    | **Deprecated, use progressJumpSteps.** Indicates the progress jump step (ms) when clicking rewind/forward button or left/right arrow key |
 | progressJumpSteps        | object            | `{ backward: 5000, forward: 5000 }`    | Indicates the progress jump step (ms) when clicking rewind/forward button or left/right arrow key|
@@ -125,6 +126,12 @@ The `controls` attribute defaults to `false` and should never be changed to `tru
 | mse.srcDuration          | number           | -        | The complete duration of the MSE audio chunks together (this is a key of the _mse_ prop) |
 | mse.onSeek               | Function (Event) | -        | The callback to be used when seek happens (this is a key of the _mse_ prop) |
 | mse.srcDuration          | number           | -        | The callback to be used when encrypted audio is detected and needs to be decrypted (this is a key of the _mse_ prop) |
+
+### Other Props
+
+| Props                    | Type              | Default | Note |
+| ------------------------ | ----------------- | ------- | ---- |
+| srcKey                   | string            | ''      | A unique key for the current audio source when not using the `src` prop, i.e., when using child `<source>` elements with a playlist. |
 
 ### Event Props
 
@@ -197,6 +204,30 @@ Then you can access the audio element like this:
 ### Media Source Extensions and Encrypted Media Extensions
 
 You can use [Media Source Extensions](https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API) and [Encrypted Media Extensions](https://developer.mozilla.org/en-US/docs/Web/API/Encrypted_Media_Extensions_API) with this player. You need to provide the complete duration, and also a onSeek and onEncrypted callbacks. The logic for feeding the audio buffer and providing the decryption keys (if using encryption) must be set in the consumer side. The player does not provide that logic. Check the [StoryBook example](https://github.com/lhz516/react-h5-audio-player/blob/master/stories/mse-eme-player.tsx) to understand better how to use.
+
+### Using `<source>` Elements
+
+You can use child `<source>` elements instead of the `src` prop, for example [to provide different file types or codecs based on browser support](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#usage_notes).
+
+```jsx
+<AudioPlayer>
+  <source src="https://example.com/audio.aac" type="audio/aac" />
+  <source src="https://example.com/audio.ogg" type="audio/ogg" />
+  <source src="https://example.com/audio.mp3" type="audio/mpeg" />
+  <source src="https://example.com/audio.wav" type="audio/wav" />
+</AudioPlayer>
+```
+
+When using `<source>` elements in playlists, use the `srcKey` prop to specify a unique identifier for the current src.
+
+```jsx
+<AudioPlayer srcKey="https://example.com/audio.wav">
+  <source src="https://example.com/audio.aac" type="audio/aac" />
+  <source src="https://example.com/audio.ogg" type="audio/ogg" />
+  <source src="https://example.com/audio.mp3" type="audio/mpeg" />
+  <source src="https://example.com/audio.wav" type="audio/wav" />
+</AudioPlayer>
+```
 
 ## Release Notes
 

--- a/src/ProgressBar.tsx
+++ b/src/ProgressBar.tsx
@@ -83,7 +83,7 @@ class ProgressBar extends Component<ProgressBarProps, ProgressBarState> {
   getCurrentProgress = (event: MouseEvent | TouchEvent): TimePosInfo => {
     const { audio, progressBar } = this.props
     const audioSrc = audio.src || audio.currentSrc
-    
+
     // A single-file progressive download (non-blob) can have transient states
     // where currentTime is not yet finite. In those cases return zeros to avoid
     // NaN propagation.

--- a/src/ProgressBar.tsx
+++ b/src/ProgressBar.tsx
@@ -82,13 +82,15 @@ class ProgressBar extends Component<ProgressBarProps, ProgressBarState> {
   // Get time info while dragging indicator by mouse or touch
   getCurrentProgress = (event: MouseEvent | TouchEvent): TimePosInfo => {
     const { audio, progressBar } = this.props
+    const audioSrc = audio.src || audio.currentSrc
+    
     // A single-file progressive download (non-blob) can have transient states
     // where currentTime is not yet finite. In those cases return zeros to avoid
     // NaN propagation.
     const isSingleFileProgressiveDownload =
-      audio.src.indexOf('blob:') !== 0 && typeof this.props.srcDuration === 'undefined'
+      audioSrc.indexOf('blob:') !== 0 && typeof this.props.srcDuration === 'undefined'
 
-    if (isSingleFileProgressiveDownload && (!audio.src || !isFinite(audio.currentTime) || !progressBar.current)) {
+    if (isSingleFileProgressiveDownload && (!audioSrc || !isFinite(audio.currentTime) || !progressBar.current)) {
       return { currentTime: 0, currentTimePos: '0%' }
     }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -702,4 +702,22 @@ describe('H5AudioPlayer', () => {
       })
     })
   })
+
+  describe('Multiple Source Elements', () => {
+    it('renders child <source> elements', () => {
+      const srcAac = 'test-audio.aac'
+      const srcMp3 = 'test-audio.mp3'
+
+      const { container } = render(
+        <H5AudioPlayer>
+          <source src={srcAac} type="audio/aac" data-testid="aac" />
+          <source src={srcMp3} type="audio/mpeg" data-testid="mp3" />
+        </H5AudioPlayer>
+      )
+
+      expect(screen.getByTestId('aac')).toBeInTheDocument()
+      expect(screen.getByTestId('mp3')).toBeInTheDocument()
+      expect(container.querySelector('audio')).not.toHaveAttribute('src')
+    })
+  })
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,10 @@ interface PlayerProps {
    */
   autoPlayAfterSrcChange?: boolean
   /**
+   * Whether to force a load of the audio after src or srcKey prop is changed
+   */
+  autoLoadAfterSrcChange?: boolean
+  /**
    * custom classNames
    */
   className?: string
@@ -90,6 +94,11 @@ interface PlayerProps {
    * HTML5 Audio tag src property
    */
   src?: string
+  /**
+   * A unique key for the current audio source, for use along with child
+   * <source> elements
+   */
+  srcKey?: string
   defaultCurrentTime?: ReactNode
   defaultDuration?: ReactNode
   volume?: number
@@ -183,7 +192,7 @@ class H5AudioPlayer extends Component<PlayerProps> {
   togglePlay = (e: React.SyntheticEvent): void => {
     e.stopPropagation()
     const audio = this.audio.current
-    if ((audio.paused || audio.ended) && audio.src) {
+    if ((audio.paused || audio.ended) && (audio.src || audio.currentSrc)) {
       this.playAudioPromise()
     } else if (!audio.paused) {
       audio.pause()
@@ -663,8 +672,13 @@ class H5AudioPlayer extends Component<PlayerProps> {
   }
 
   componentDidUpdate(prevProps: PlayerProps): void {
-    const { src, autoPlayAfterSrcChange } = this.props
-    if (prevProps.src !== src) {
+    const { src, srcKey, autoPlayAfterSrcChange, autoLoadAfterSrcChange } = this.props
+
+    if (prevProps.src !== src || prevProps.srcKey !== srcKey) {
+      if (autoLoadAfterSrcChange && this.audio.current) {
+        this.audio.current.load()
+      }
+
       if (autoPlayAfterSrcChange) {
         this.playAudioPromise()
       } else {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,7 +36,8 @@ interface PlayerProps {
    */
   autoPlayAfterSrcChange?: boolean
   /**
-   * Whether to force a load of the audio after src or srcKey prop is changed
+   * Whether to load the audio after changing the src. This is necessary when
+   * using child `<source>` elements
    */
   autoLoadAfterSrcChange?: boolean
   /**
@@ -95,8 +96,8 @@ interface PlayerProps {
    */
   src?: string
   /**
-   * A unique key for the current audio source, for use along with child
-   * <source> elements
+   * A unique key for the current audio source when not using the `src` prop,
+   * i.e., when using child <source> elements
    */
   srcKey?: string
   defaultCurrentTime?: ReactNode
@@ -672,7 +673,7 @@ class H5AudioPlayer extends Component<PlayerProps> {
   }
 
   componentDidUpdate(prevProps: PlayerProps): void {
-    const { src, srcKey, autoPlayAfterSrcChange, autoLoadAfterSrcChange } = this.props
+    const { src, srcKey, autoPlayAfterSrcChange, autoLoadAfterSrcChange = true } = this.props
 
     if (prevProps.src !== src || prevProps.srcKey !== srcKey) {
       if (autoLoadAfterSrcChange && this.audio.current) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import React, {
   CSSProperties,
   ReactElement,
   Key,
+  Children,
 } from 'react'
 import { Icon } from '@iconify/react'
 import ProgressBar from './ProgressBar'
@@ -35,11 +36,6 @@ interface PlayerProps {
    * Whether to play audio after src prop is changed
    */
   autoPlayAfterSrcChange?: boolean
-  /**
-   * Whether to load the audio after changing the src. This is necessary when
-   * using child `<source>` elements
-   */
-  autoLoadAfterSrcChange?: boolean
   /**
    * custom classNames
    */
@@ -95,11 +91,6 @@ interface PlayerProps {
    * HTML5 Audio tag src property
    */
   src?: string
-  /**
-   * A unique key for the current audio source when not using the `src` prop,
-   * i.e., when using child <source> elements
-   */
-  srcKey?: string
   defaultCurrentTime?: ReactNode
   defaultDuration?: ReactNode
   volume?: number
@@ -673,13 +664,26 @@ class H5AudioPlayer extends Component<PlayerProps> {
   }
 
   componentDidUpdate(prevProps: PlayerProps): void {
-    const { src, srcKey, autoPlayAfterSrcChange, autoLoadAfterSrcChange = true } = this.props
+    const { src, autoPlayAfterSrcChange, children } = this.props
 
-    if (prevProps.src !== src || prevProps.srcKey !== srcKey) {
-      if (autoLoadAfterSrcChange && this.audio.current) {
-        this.audio.current.load()
-      }
+    let isAudioSrcChanged = false
 
+    if (prevProps.src !== src) {
+      isAudioSrcChanged = true
+    } else if (children && Children.count(children) > 0) {
+      const prevSrcs: string[] = []
+      Children.toArray(prevProps.children).forEach((c) => {
+        if (isValidElement(c) && c.type === 'source') {
+          prevSrcs.push(c.key)
+        }
+      })
+
+      isAudioSrcChanged = Children.toArray(children).some(
+        (c) => isValidElement(c) && c.type === 'source' && !prevSrcs.includes(c.key)
+      )
+    }
+
+    if (isAudioSrcChanged) {
       if (autoPlayAfterSrcChange) {
         this.playAudioPromise()
       } else {

--- a/stories/edge-cases.stories.js
+++ b/stories/edge-cases.stories.js
@@ -49,5 +49,5 @@ export const ChildSourceElements = {
     </AudioPlayer>  
   ),
 
-  name: "Child <source> elements",
+  name: "Source elements",
 };

--- a/stories/edge-cases.stories.js
+++ b/stories/edge-cases.stories.js
@@ -1,5 +1,5 @@
 import { action } from "storybook/actions";
-import { SAMPLE_MP3_URL } from "./utils";
+import { SAMPLE_URL_A_MP3, SAMPLE_URL_A_FLAC } from "./utils";
 import AudioPlayer from "../src/index.tsx";
 import React from "react";
 
@@ -39,4 +39,15 @@ export const InvalidSrc = {
   ),
 
   name: "Invalid src",
+};
+
+export const ChildSourceElements = {
+  render: () => (
+    <AudioPlayer>
+      <source src={SAMPLE_URL_A_FLAC} type="audio/flac" />
+      <source src={SAMPLE_URL_A_MP3} type="audio/mpeg" />
+    </AudioPlayer>  
+  ),
+
+  name: "Child <source> elements",
 };

--- a/stories/edge-cases.stories.js
+++ b/stories/edge-cases.stories.js
@@ -1,5 +1,5 @@
 import { action } from "storybook/actions";
-import { SAMPLE_URL_A_MP3, SAMPLE_URL_A_FLAC } from "./utils";
+import { BRAHMS_FLAC_URL, BRAHMS_MP3_URL } from "./utils";
 import AudioPlayer from "../src/index.tsx";
 import React from "react";
 
@@ -44,8 +44,8 @@ export const InvalidSrc = {
 export const ChildSourceElements = {
   render: () => (
     <AudioPlayer>
-      <source src={SAMPLE_URL_A_FLAC} type="audio/flac" />
-      <source src={SAMPLE_URL_A_MP3} type="audio/mpeg" />
+      <source src={BRAHMS_FLAC_URL} type="audio/flac" />
+      <source src={BRAHMS_MP3_URL} type="audio/mpeg" />
     </AudioPlayer>  
   ),
 

--- a/stories/playlist.stories.js
+++ b/stories/playlist.stories.js
@@ -2,12 +2,12 @@ import {
   SAMPLE_MP3_URL,
   SAMPLE_MP3_URL_B,
   SAMPLE_MP3_URL_C,
-  SAMPLE_URL_A_OGG,
-  SAMPLE_URL_A_MP3,
-  SAMPLE_URL_A_FLAC,
-  SAMPLE_URL_B_OGG,
-  SAMPLE_URL_B_MP3,
-  SAMPLE_URL_B_FLAC,
+  BRAHMS_OGG_URL,
+  BRAHMS_MP3_URL,
+  BRAHMS_FLAC_URL,
+  MOZART_OGG_URL,
+  MOZART_MP3_URL,
+  MOZART_FLAC_URL,
 } from './utils.js'
 import PlayList from "./playlist.tsx";
 import React from "react";
@@ -20,19 +20,19 @@ const mp3Playlist = [
 
 const multiSourcePlaylist = [
   {
-    src: SAMPLE_URL_A_OGG,
+    src: BRAHMS_OGG_URL,
     type: 'audio/ogg',
     additionalSrcs: [
-      { src: SAMPLE_URL_A_MP3, type: 'audio/mpeg' },
-      { src: SAMPLE_URL_A_FLAC, type: 'audio/flac' },
+      { src: BRAHMS_MP3_URL, type: 'audio/mpeg' },
+      { src: BRAHMS_FLAC_URL, type: 'audio/flac' },
     ]
   },
   {
-    src: SAMPLE_URL_B_OGG,
+    src: MOZART_OGG_URL,
     type: 'audio/ogg',
     additionalSrcs: [
-      { src: SAMPLE_URL_B_MP3, type: 'audio/mpeg' },
-      { src: SAMPLE_URL_B_FLAC,type: 'audio/flac' },
+      { src: MOZART_MP3_URL, type: 'audio/mpeg' },
+      { src: MOZART_FLAC_URL, type: 'audio/flac' },
     ]
   }  
 ]

--- a/stories/playlist.stories.js
+++ b/stories/playlist.stories.js
@@ -12,29 +12,23 @@ import {
 import PlayList from "./playlist.tsx";
 import React from "react";
 
-const mp3Playlist = [
-  { src: SAMPLE_MP3_URL, type: 'audio/mpeg' },
-  { src: SAMPLE_MP3_URL_B, type: 'audio/mpeg' },
-  { src: SAMPLE_MP3_URL_C, type: 'audio/mpeg'},
+const singleSourcePlaylist = [
+  SAMPLE_MP3_URL,
+  SAMPLE_MP3_URL_B,
+  SAMPLE_MP3_URL_C,
 ]
 
 const multiSourcePlaylist = [
-  {
-    src: BRAHMS_OGG_URL,
-    type: 'audio/ogg',
-    additionalSrcs: [
+  [
+      { src: BRAHMS_OGG_URL, type: 'audio/ogg' },
       { src: BRAHMS_MP3_URL, type: 'audio/mpeg' },
       { src: BRAHMS_FLAC_URL, type: 'audio/flac' },
-    ]
-  },
-  {
-    src: MOZART_OGG_URL,
-    type: 'audio/ogg',
-    additionalSrcs: [
-      { src: MOZART_MP3_URL, type: 'audio/mpeg' },
-      { src: MOZART_FLAC_URL, type: 'audio/flac' },
-    ]
-  }  
+  ],
+  [
+    { src: MOZART_OGG_URL, type: 'audio/ogg' },
+    { src: MOZART_MP3_URL, type: 'audio/mpeg' },
+    { src: MOZART_FLAC_URL, type: 'audio/flac' },
+  ]
 ]
 
 export default {
@@ -43,11 +37,11 @@ export default {
 };
 
 export const Playlist = {
-  render: () => <PlayList playlist={mp3Playlist} />,
+  render: () => <PlayList playlist={singleSourcePlaylist} />,
   name: "Playlist",
 };
 
 export const PlaylistWithSourceElements = {
-  render: () => <PlayList playlist={multiSourcePlaylist} useSourceElements={true} />,
+  render: () => <PlayList playlist={multiSourcePlaylist} />,
   name: "Playlist with <source> elements",
 };

--- a/stories/playlist.stories.js
+++ b/stories/playlist.stories.js
@@ -1,7 +1,41 @@
-import { SAMPLE_MP3_URL } from "./utils";
-import AudioPlayer from "../src/index.tsx";
+import {
+  SAMPLE_MP3_URL,
+  SAMPLE_MP3_URL_B,
+  SAMPLE_MP3_URL_C,
+  SAMPLE_URL_A_OGG,
+  SAMPLE_URL_A_MP3,
+  SAMPLE_URL_A_FLAC,
+  SAMPLE_URL_B_OGG,
+  SAMPLE_URL_B_MP3,
+  SAMPLE_URL_B_FLAC,
+} from './utils.js'
 import PlayList from "./playlist.tsx";
 import React from "react";
+
+const mp3Playlist = [
+  { src: SAMPLE_MP3_URL, type: 'audio/mpeg' },
+  { src: SAMPLE_MP3_URL_B, type: 'audio/mpeg' },
+  { src: SAMPLE_MP3_URL_C, type: 'audio/mpeg'},
+]
+
+const multiSourcePlaylist = [
+  {
+    src: SAMPLE_URL_A_OGG,
+    type: 'audio/ogg',
+    additionalSrcs: [
+      { src: SAMPLE_URL_A_MP3, type: 'audio/mpeg' },
+      { src: SAMPLE_URL_A_FLAC, type: 'audio/flac' },
+    ]
+  },
+  {
+    src: SAMPLE_URL_B_OGG,
+    type: 'audio/ogg',
+    additionalSrcs: [
+      { src: SAMPLE_URL_B_MP3, type: 'audio/mpeg' },
+      { src: SAMPLE_URL_B_FLAC,type: 'audio/flac' },
+    ]
+  }  
+]
 
 export default {
   title: "Play List",
@@ -9,6 +43,11 @@ export default {
 };
 
 export const Playlist = {
-  render: () => <PlayList />,
-  name: "playlist",
+  render: () => <PlayList playlist={mp3Playlist} />,
+  name: "Playlist",
+};
+
+export const PlaylistWithSourceElements = {
+  render: () => <PlayList playlist={multiSourcePlaylist} useSourceElements={true} />,
+  name: "Playlist with <source> elements",
 };

--- a/stories/playlist.tsx
+++ b/stories/playlist.tsx
@@ -1,47 +1,86 @@
 import React, { Component } from 'react'
 import AudioPlayer from '../src/index'
 
-const playlist = [
-  { name: 'SoundHelix-Song-9', src: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-9.mp3' },
-  { name: 'SoundHelix-Song-4', src: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3' },
-  { name: 'SoundHelix-Song-8', src: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-8.mp3' },
-]
+interface Track {
+  src: string
+  type: string
+  additionalSrcs: [
+    {
+      src: string
+      type: string
+    }
+  ]
+}
+
+interface PlaylistProps {
+  playlist: Track[]
+  useSourceElements?: boolean
+}
 
 interface PlayListState {
   currentMusicIndex: number
 }
 
-class PlayList extends Component<null, PlayListState> {
+class PlayList extends Component<PlaylistProps, PlayListState> {
+  playlist: Track[]
+  useSourceElements?: boolean = false
+
   state = {
     currentMusicIndex: 0,
   }
 
+  constructor(props: PlaylistProps) {
+    super(props)
+    this.playlist = props.playlist
+    this.useSourceElements = props.useSourceElements
+  }
+
   handleClickPrevious = (): void => {
     this.setState((prevState) => ({
-      currentMusicIndex: prevState.currentMusicIndex === 0 ? playlist.length - 1 : prevState.currentMusicIndex - 1,
+      currentMusicIndex: prevState.currentMusicIndex === 0 ? this.playlist.length - 1 : prevState.currentMusicIndex - 1,
     }))
   }
 
   handleClickNext = (): void => {
     this.setState((prevState) => ({
-      currentMusicIndex: prevState.currentMusicIndex < playlist.length - 1 ? prevState.currentMusicIndex + 1 : 0,
+      currentMusicIndex: prevState.currentMusicIndex < this.playlist.length - 1 ? prevState.currentMusicIndex + 1 : 0,
     }))
   }
 
   render(): React.ReactNode {
     const { currentMusicIndex } = this.state
+    const track = this.playlist[currentMusicIndex]
+
     return (
       <div>
         <p>currentMusicIndex: {currentMusicIndex}</p>
-        <AudioPlayer
-          onEnded={this.handleClickNext}
-          autoPlayAfterSrcChange={true}
-          showSkipControls={true}
-          showJumpControls={false}
-          src={playlist[currentMusicIndex].src}
-          onClickPrevious={this.handleClickPrevious}
-          onClickNext={this.handleClickNext}
-        />
+
+        {this.useSourceElements ? (
+          <AudioPlayer
+            onEnded={this.handleClickNext}
+            autoPlayAfterSrcChange={true}
+            showSkipControls={true}
+            showJumpControls={false}
+            onClickPrevious={this.handleClickPrevious}
+            onClickNext={this.handleClickNext}
+            srcKey={track.src}
+            autoLoadAfterSrcChange={true}
+          >
+            <source src={track.src} type={track.type} />
+            {track.additionalSrcs &&
+              track.additionalSrcs.map(({ src, type }) => <source key={src} src={src} type={type} />)}
+          </AudioPlayer>
+        ) : (
+          <AudioPlayer
+            onEnded={this.handleClickNext}
+            autoPlayAfterSrcChange={true}
+            showSkipControls={true}
+            showJumpControls={false}
+            src={track.src}
+            onClickPrevious={this.handleClickPrevious}
+            onClickNext={this.handleClickNext}
+          />
+        )}
       </div>
     )
   }

--- a/stories/playlist.tsx
+++ b/stories/playlist.tsx
@@ -1,20 +1,13 @@
 import React, { Component } from 'react'
 import AudioPlayer from '../src/index'
 
-interface Track {
+interface AudioSource {
   src: string
-  type: string
-  additionalSrcs?: [
-    {
-      src: string
-      type: string
-    }
-  ]
+  type?: string
 }
 
 interface PlaylistProps {
-  playlist: Track[]
-  useSourceElements?: boolean
+  playlist: string[] | AudioSource[][]
 }
 
 interface PlayListState {
@@ -22,8 +15,7 @@ interface PlayListState {
 }
 
 class PlayList extends Component<PlaylistProps, PlayListState> {
-  playlist: Track[]
-  useSourceElements?: boolean = false
+  playlist: string[] | AudioSource[][]
 
   state = {
     currentMusicIndex: 0,
@@ -32,7 +24,6 @@ class PlayList extends Component<PlaylistProps, PlayListState> {
   constructor(props: PlaylistProps) {
     super(props)
     this.playlist = props.playlist
-    this.useSourceElements = props.useSourceElements
   }
 
   handleClickPrevious = (): void => {
@@ -50,36 +41,24 @@ class PlayList extends Component<PlaylistProps, PlayListState> {
   render(): React.ReactNode {
     const { currentMusicIndex } = this.state
     const track = this.playlist[currentMusicIndex]
+    const singleStringSrc = typeof track === 'string' ? track : null
+    const multipleSrcs: AudioSource[] | null = Array.isArray(track) ? track : null
 
     return (
       <div>
         <p>currentMusicIndex: {currentMusicIndex}</p>
 
-        {this.useSourceElements ? (
-          <AudioPlayer
-            srcKey={track.src}
-            onEnded={this.handleClickNext}
-            autoPlayAfterSrcChange={true}
-            showSkipControls={true}
-            showJumpControls={false}
-            onClickPrevious={this.handleClickPrevious}
-            onClickNext={this.handleClickNext}
-          >
-            <source src={track.src} type={track.type} />
-            {track.additionalSrcs &&
-              track.additionalSrcs.map(({ src, type }) => <source key={src} src={src} type={type} />)}
-          </AudioPlayer>
-        ) : (
-          <AudioPlayer
-            src={track.src}
-            onEnded={this.handleClickNext}
-            autoPlayAfterSrcChange={true}
-            showSkipControls={true}
-            showJumpControls={false}
-            onClickPrevious={this.handleClickPrevious}
-            onClickNext={this.handleClickNext}
-          />
-        )}
+        <AudioPlayer
+          onEnded={this.handleClickNext}
+          autoPlayAfterSrcChange={true}
+          showSkipControls={true}
+          showJumpControls={false}
+          onClickPrevious={this.handleClickPrevious}
+          onClickNext={this.handleClickNext}
+          {...(singleStringSrc ? { src: singleStringSrc } : {})}
+        >
+          {multipleSrcs && multipleSrcs.map(({ src, type }) => <source key={src} src={src} type={type} />)}
+        </AudioPlayer>
       </div>
     )
   }

--- a/stories/playlist.tsx
+++ b/stories/playlist.tsx
@@ -4,7 +4,7 @@ import AudioPlayer from '../src/index'
 interface Track {
   src: string
   type: string
-  additionalSrcs: [
+  additionalSrcs?: [
     {
       src: string
       type: string
@@ -57,14 +57,13 @@ class PlayList extends Component<PlaylistProps, PlayListState> {
 
         {this.useSourceElements ? (
           <AudioPlayer
+            srcKey={track.src}
             onEnded={this.handleClickNext}
             autoPlayAfterSrcChange={true}
             showSkipControls={true}
             showJumpControls={false}
             onClickPrevious={this.handleClickPrevious}
             onClickNext={this.handleClickNext}
-            srcKey={track.src}
-            autoLoadAfterSrcChange={true}
           >
             <source src={track.src} type={track.type} />
             {track.additionalSrcs &&
@@ -72,11 +71,11 @@ class PlayList extends Component<PlaylistProps, PlayListState> {
           </AudioPlayer>
         ) : (
           <AudioPlayer
+            src={track.src}
             onEnded={this.handleClickNext}
             autoPlayAfterSrcChange={true}
             showSkipControls={true}
             showJumpControls={false}
-            src={track.src}
             onClickPrevious={this.handleClickPrevious}
             onClickNext={this.handleClickNext}
           />

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -1,1 +1,11 @@
 export const SAMPLE_MP3_URL = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-9.mp3'
+export const SAMPLE_MP3_URL_B = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3'
+export const SAMPLE_MP3_URL_C = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-8.mp3'
+
+export const SAMPLE_URL_A_OGG = 'https://archive.org/download/MusopenCollectionAsFlac/Brahms_SymphonyNo.3inFMajor/JohannesBrahms-SymphonyNo.3InFMajorOp.90-03-PocoAllegretto.ogg'
+export const SAMPLE_URL_A_MP3 = 'https://archive.org/download/MusopenCollectionAsFlac/Brahms_SymphonyNo.3inFMajor/JohannesBrahms-SymphonyNo.3InFMajorOp.90-03-PocoAllegretto.mp3'
+export const SAMPLE_URL_A_FLAC = 'https://archive.org/download/MusopenCollectionAsFlac/Brahms_SymphonyNo.3inFMajor/JohannesBrahms-SymphonyNo.3InFMajorOp.90-03-PocoAllegretto.flac'
+
+export const SAMPLE_URL_B_OGG = 'https://archive.org/download/MusopenCollectionAsFlac/Mozart_StringQuartetNo.15inDMinorK421/WolfgangAmadeusMozart-StringQuartetNo.15InDMinorK421-03-Minuetto.ogg'
+export const SAMPLE_URL_B_MP3 = 'https://archive.org/download/MusopenCollectionAsFlac/Mozart_StringQuartetNo.15inDMinorK421/WolfgangAmadeusMozart-StringQuartetNo.15InDMinorK421-03-Minuetto.mp3'
+export const SAMPLE_URL_B_FLAC = 'https://archive.org/download/MusopenCollectionAsFlac/Mozart_StringQuartetNo.15inDMinorK421/WolfgangAmadeusMozart-StringQuartetNo.15InDMinorK421-03-Minuetto.flac'

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -2,10 +2,10 @@ export const SAMPLE_MP3_URL = 'https://www.soundhelix.com/examples/mp3/SoundHeli
 export const SAMPLE_MP3_URL_B = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3'
 export const SAMPLE_MP3_URL_C = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-8.mp3'
 
-export const SAMPLE_URL_A_OGG = 'https://archive.org/download/MusopenCollectionAsFlac/Brahms_SymphonyNo.3inFMajor/JohannesBrahms-SymphonyNo.3InFMajorOp.90-03-PocoAllegretto.ogg'
-export const SAMPLE_URL_A_MP3 = 'https://archive.org/download/MusopenCollectionAsFlac/Brahms_SymphonyNo.3inFMajor/JohannesBrahms-SymphonyNo.3InFMajorOp.90-03-PocoAllegretto.mp3'
-export const SAMPLE_URL_A_FLAC = 'https://archive.org/download/MusopenCollectionAsFlac/Brahms_SymphonyNo.3inFMajor/JohannesBrahms-SymphonyNo.3InFMajorOp.90-03-PocoAllegretto.flac'
+export const BRAHMS_OGG_URL = 'https://archive.org/download/MusopenCollectionAsFlac/Brahms_SymphonyNo.3inFMajor/JohannesBrahms-SymphonyNo.3InFMajorOp.90-03-PocoAllegretto.ogg'
+export const BRAHMS_MP3_URL = 'https://archive.org/download/MusopenCollectionAsFlac/Brahms_SymphonyNo.3inFMajor/JohannesBrahms-SymphonyNo.3InFMajorOp.90-03-PocoAllegretto.mp3'
+export const BRAHMS_FLAC_URL = 'https://archive.org/download/MusopenCollectionAsFlac/Brahms_SymphonyNo.3inFMajor/JohannesBrahms-SymphonyNo.3InFMajorOp.90-03-PocoAllegretto.flac'
 
-export const SAMPLE_URL_B_OGG = 'https://archive.org/download/MusopenCollectionAsFlac/Mozart_StringQuartetNo.15inDMinorK421/WolfgangAmadeusMozart-StringQuartetNo.15InDMinorK421-03-Minuetto.ogg'
-export const SAMPLE_URL_B_MP3 = 'https://archive.org/download/MusopenCollectionAsFlac/Mozart_StringQuartetNo.15inDMinorK421/WolfgangAmadeusMozart-StringQuartetNo.15InDMinorK421-03-Minuetto.mp3'
-export const SAMPLE_URL_B_FLAC = 'https://archive.org/download/MusopenCollectionAsFlac/Mozart_StringQuartetNo.15inDMinorK421/WolfgangAmadeusMozart-StringQuartetNo.15InDMinorK421-03-Minuetto.flac'
+export const MOZART_OGG_URL = 'https://archive.org/download/MusopenCollectionAsFlac/Mozart_StringQuartetNo.15inDMinorK421/WolfgangAmadeusMozart-StringQuartetNo.15InDMinorK421-03-Minuetto.ogg'
+export const MOZART_MP3_URL = 'https://archive.org/download/MusopenCollectionAsFlac/Mozart_StringQuartetNo.15inDMinorK421/WolfgangAmadeusMozart-StringQuartetNo.15InDMinorK421-03-Minuetto.mp3'
+export const MOZART_FLAC_URL = 'https://archive.org/download/MusopenCollectionAsFlac/Mozart_StringQuartetNo.15inDMinorK421/WolfgangAmadeusMozart-StringQuartetNo.15InDMinorK421-03-Minuetto.flac'


### PR DESCRIPTION
Fixes #249.
 
This adds support for multiple `<source>` elements as an alternative to a single `src` attribute. Example:

```js
<AudioPlayer
  srcKey={track.key}
  ...
>
  <source src={track.aacUrl} type="audio/aac" />
  <source src={track.oggUrl} type="audio/ogg" />
  <source src={track.mp3Url} type="audio/mpeg" />
  <source src={track.wavUrl} type="audio/wav" />
</AudioPlayer>
```

I'm using the `currentSrc` attribute to achieve this, based on this info:
<img width="813" height="432" alt="Screenshot 2025-01-08 at 20 37 11" src="https://github.com/user-attachments/assets/f6f97434-2677-4aba-91d1-4afc40d9bfd5" />
<img width="798" height="606" alt="Screenshot 2025-01-08 at 20 34 24" src="https://github.com/user-attachments/assets/99ff23d4-89ae-417d-89e9-69cf9be68af6" />

https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentSrc
